### PR TITLE
Initialize page improvements + private tags

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -213,7 +213,7 @@ def sync_delicious(request):
 @render_to('accounts/edit_tag.html')
 def edit_tags(request):
     user = request.user
-    tags = Tag.objects.filter(user=user)
+    tags = Tag.objects.filter(user=user, is_private=True)
     tag_dict = {}
     for tag in tags:
         if tag.name in tag_dict:

--- a/eyebrowse/views.py
+++ b/eyebrowse/views.py
@@ -140,6 +140,7 @@ def add_tag(request):
         if tags.count() > 0:
             tag = tags[0]
             tag.name = name
+            tag.is_private = True
             tag.save()
         else:
 

--- a/scripts/make_tags_private.py
+++ b/scripts/make_tags_private.py
@@ -1,0 +1,15 @@
+import setup_django
+import json
+from tags.models import CommonTag, TagCollection
+from django.contrib.auth.models import User
+
+def make_tags_private():
+  tags = Tag.objects.all()
+
+  for tag in tags:
+    if tag.name is not None:
+      tag.is_private = True
+      tag.save()
+
+if __name__ == '__main__':
+  make_tags_private()

--- a/tags/views.py
+++ b/tags/views.py
@@ -291,7 +291,6 @@ def initialize_page(request):
             try:
               common_tag = CommonTag.objects.get(name=name)
               vt = Tag(
-                user=user,
                 page=p,
                 common_tag=common_tag
               )

--- a/tags/views.py
+++ b/tags/views.py
@@ -226,6 +226,7 @@ def initialize_page(request):
 
   if request.POST:
     url = process_url(request.POST.get('url'))
+    favIconUrl = request.POST.get('favIconUrl')
     domain_name = request.POST.get('domain_name')
     title = request.POST.get('title')
     add_usertags = request.POST.get('add_usertags')
@@ -233,11 +234,13 @@ def initialize_page(request):
     domain = '{uri.scheme}://{uri.netloc}/'.format(uri=urlparse(url))
     errors['add_page'] = []
 
-    domain_name = domain if domain_name == "" else domain_name
     title = url if title == "" else title
 
     # Add domain
-    d, d_created = Domain.objects.get_or_create(url=domain, name=domain_name)
+    d, d_created = Domain.objects.get_or_create(url=domain)
+    if domain_name is not None:
+      d.name = domain_name
+
     d.save()
 
     # Add page

--- a/tags/views.py
+++ b/tags/views.py
@@ -339,6 +339,7 @@ def add_vote(request):
     url = process_url(request.POST.get('url'))
     highlight = request.POST.get('highlight')
     errors['add_vote'] = []
+    vt = None
 
     try:
       vt = Tag.objects.get(
@@ -346,19 +347,15 @@ def add_vote(request):
         highlight__highlight=highlight, 
         page__url=url,
       )
-
-      vote_count = len(Vote.objects.filter(tag=vt, voter=user))
-      
-      # Ensure user hasn't already voted
-      if vote_count == 0:
-        vote = Vote(tag=vt, voter=user)
-        vote.save()
-        success = True
-
-      vote_count = len(Vote.objects.filter(tag=vt))
-
     except Tag.DoesNotExist:
       errors['add_vote'].append("Tag " + tag_name + " does not exist")
+
+    if vt is not None:
+      v, created = Vote.objects.get_or_create(tag=vt, voter=user)
+      v.save()
+
+      vote_count = len(Vote.objects.filter(tag=vt))
+      success = True
 
   return {
     'success': success,


### PR DESCRIPTION
1) Script to make existing tags actually private
2) Only display tags with attribute is_private
3) Improve dupe checks on add_vote
4) Change highlight to use ids
5) Modify initialize page to go with front-end changes
6) Remove user from being attached to a page-level tag

Steps:
1) Run script